### PR TITLE
Introduce SmartPackageReference

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <EnableSourceLink Condition=" '$(NCrunch)' == '1' ">false</EnableSourceLink>
 
     <ProjectName Condition=" '$(ProjectName)' == '' ">$(MSBuildProjectName)</ProjectName>
-    <BaseOutputPath>$(MSBuildThisFileDirectory)..\build\</BaseOutputPath>
+    <BaseOutputPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\build\))</BaseOutputPath>
     <BaseIntermediateOutputPath>$(BaseOutputPath)obj\$(ProjectName)\</BaseIntermediateOutputPath>
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
 
@@ -18,10 +18,6 @@
     <Company>WiX Toolset</Company>
     <Copyright>Copyright (c) .NET Foundation and contributors. All rights reserved.</Copyright>
     <Product>WiX Toolset</Product>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <WixToolsetRootFolder>$(MSBuildThisFileDirectory)..\..\</WixToolsetRootFolder>
   </PropertyGroup>
 
   <Import Project="Cpp.Build.props" Condition=" '$(MSBuildProjectExtension)'=='.vcxproj' " />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Replace PackageReferences with ProjectReferences when the projects can be found in .sln.
+  See the original here: https://github.com/dotnet/sdk/issues/1151#issuecomment-385133284
+-->
+<Project>
+  <PropertyGroup>
+    <ReplacePackageReferences>true</ReplacePackageReferences>
+    <TheSolutionPath Condition=" '$(NCrunch)'=='' ">$(SolutionPath)</TheSolutionPath>
+    <TheSolutionPath Condition=" '$(NCrunch)'=='1' ">$(NCrunchOriginalSolutionPath)</TheSolutionPath>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(ReplacePackageReferences) AND '$(TheSolutionPath)' != '' AND '$(TheSolutionPath)' != '*undefined*' AND Exists('$(TheSolutionPath)')">
+
+      <PropertyGroup>
+        <SolutionFileContent>$([System.IO.File]::ReadAllText($(TheSolutionPath)))</SolutionFileContent>
+        <SmartSolutionDir>$([System.IO.Path]::GetDirectoryName( $(TheSolutionPath) ))</SmartSolutionDir>
+        <RegexPattern>(?&lt;="[PackageName]", ")(.*)(?=", ")</RegexPattern>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <!-- Keep the identity of the PackageReference -->
+        <SmartPackageReference Include="@(PackageReference)">
+          <PackageName>%(Identity)</PackageName>
+          <InSolution>$(SolutionFileContent.Contains('\%(Identity).csproj'))</InSolution>
+        </SmartPackageReference>
+
+        <!-- Filter them by mapping them to another ItemGroup using the WithMetadataValue item function -->
+        <PackageInSolution Include="@(SmartPackageReference->WithMetadataValue('InSolution', True))">
+          <Pattern>$(RegexPattern.Replace('[PackageName]','%(PackageName)') )</Pattern>
+          <SmartPath>$([System.Text.RegularExpressions.Regex]::Match('$(SolutionFileContent)', '%(Pattern)'))</SmartPath>
+        </PackageInSolution>
+
+        <ProjectReference  Include="@(PackageInSolution->'$(SmartSolutionDir)\%(SmartPath)' )"/>
+
+        <!-- Remove the package references that are now referenced as projects -->
+        <PackageReference Remove="@(PackageInSolution->'%(PackageName)' )"/>
+      </ItemGroup>
+
+    </When>
+  </Choose>
+</Project>


### PR DESCRIPTION
SmartPackageReference is a little piece of MSBuild magic that switches
PackageReferences to ProjetReferences when a matching project is found
in a .sln.